### PR TITLE
Select participant data from match info

### DIFF
--- a/app/riot_ingest_dag.py
+++ b/app/riot_ingest_dag.py
@@ -86,29 +86,33 @@ def fetch_match_details(match_id: str) -> Dict[str, Any]:
     response.raise_for_status()
     return response.json()
 
-def process_match_data(match_data: Dict[str, Any]) -> Dict[str, Any]:
+def process_match_data(match_data: Dict[str, Any], puuid: str) -> Dict[str, Any]:
     """
     Extract relevant data from match response.
     
     Args:
         match_data: Raw match data from API
+        puuid: Player unique identifier to locate participant info
     
     Returns:
         Processed match data
     """
     metadata = match_data.get("metadata", {})
     info = match_data.get("info", {})
-    
+
+    participants = info.get("participants", [])
+    player = next((p for p in participants if p.get("puuid") == puuid), {})
+
     return {
         "match_id": metadata.get("match_id"),
         "game_datetime": datetime.fromtimestamp(info.get("game_datetime", 0) / 1000),
-        "placement": info.get("placement"),
-        "level": info.get("level"),
-        "gold_left": info.get("gold_left"),
-        "last_round": info.get("last_round"),
-        "players_eliminated": info.get("players_eliminated"),
-        "time_eliminated": info.get("time_eliminated"),
-        "raw_data": json.dumps(match_data)
+        "placement": player.get("placement"),
+        "level": player.get("level"),
+        "gold_left": player.get("gold_left"),
+        "last_round": player.get("last_round"),
+        "players_eliminated": player.get("players_eliminated"),
+        "time_eliminated": player.get("time_eliminated"),
+        "raw_data": json.dumps(match_data),
     }
 
 def fetch_and_store_matches(**context) -> None:
@@ -144,7 +148,7 @@ def fetch_and_store_matches(**context) -> None:
         for match_id in match_ids:
             try:
                 match_data = fetch_match_details(match_id)
-                processed_data = process_match_data(match_data)
+                processed_data = process_match_data(match_data, puuid)
                 
                 # Insert into database
                 conn.execute("""


### PR DESCRIPTION
## Summary
- pull specific participant stats from match data using puuid
- forward puuid when processing each match

## Testing
- `ruff check app/riot_ingest_dag.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a957a977c8331b8911c43e1919927