### PR TITLE
Fix Airflow config and ensure DAG discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,7 @@ cython_debug/
 # Environment files
 .env
 *.env
-!airflow.env
+!app/configs/airflow.env
 
 # Data files
 data/

--- a/app/README.md
+++ b/app/README.md
@@ -7,6 +7,6 @@
 - Docker Compose based
 
 ## Usage:
-1. Set your Riot API key in `configs/airflow.env`
+1. Set your Riot API key in `configs/airflow.env` (optionally adjust `AIRFLOW_UID`)
 2. Run `docker-compose up`
 3. Airflow Web UI on localhost:8080

--- a/app/configs/airflow.env
+++ b/app/configs/airflow.env
@@ -1,1 +1,2 @@
 RIOT_API_KEY=your_riot_api_key_here
+AIRFLOW_UID=50000

--- a/app/dags/riot_ingest_dag.py
+++ b/app/dags/riot_ingest_dag.py
@@ -210,4 +210,4 @@ with DAG(
     )
 
     # Set up task dependencies
-    daily_update
+    historical_load >> daily_update


### PR DESCRIPTION
## Summary
- move airflow.env under `configs/` and track it via `.gitignore`
- update README usage instructions
- add package structure for `dags`
- finish DAG dependency chain

## Testing
- `pytest -q`
- `python - <<'PY'
from airflow.models import DagBag
bag = DagBag(dag_folder='app/dags', include_examples=False)
print('dags', list(bag.dags.keys()))
print('import_errors', bag.import_errors)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_686a9504d72c8331b887a24d5772bd9f